### PR TITLE
Document the number of flops for +, -, * and /

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,13 @@ Two basic linear algebra tasks are used below to compare the performance of exte
 | compatible with **[GenericSVD.jl](https://github.com/JuliaLinearAlgebra/GenericSVD.jl)**                         | ✔️          | ✔️      | ✔️          | ❌       | ❌    | ✔️          | ✔️       |
 | floating-point introspection `minfloat`, `eps`         | ✔️          | ✔️      | ✔️          | ❌       | ✔️    | ✔️          | ✔️       |
 
+## Complexity of operations
+
+The number of flops per operation scales cubically for `*` and `/` and quadratically for `+` and `-` as a function of `N`. Counting explicit fma's as a single operation, the number of flops for `N` in the range `2:8` is:
+
+| Operation | Number of flops     |
+|-----------|---------------------|
+| `+`       | 3N² + 4N - 9        |
+| `-`       | 3N² + 4N - 9        |
+| `*`       | 2N³ - 4N² + 9N - 9  |
+| `/`       | 6N³ - 2N² - 11N + 5 |


### PR DESCRIPTION
For people using this package it would be useful to estimate the expected overhead when incrementing the precision, so I ran this package through GFlops (with a patch to count fma's too), and fitted the number of flops (fma counted as 1 op) to a cubical polynomial. Turns out they fit exactly for N=2:8, so I guess these expressions are correct.

To replicate, try this:

```julia
julia> using MultiFloat, GFlops

julia> Polynomials.fit(2:8, [GFlops.flop(@count_ops MultiFloat{Float64,N}(1.0) / MultiFloat{Float64,N}(2.0)) for N=2:8], 3)
Polynomial(5.000000000000803 - 11.000000000000755*x - 1.9999999999998108*x^2 + 5.999999999999988*x^3)

julia> Polynomials.fit(2:8, [GFlops.flop(@count_ops MultiFloat{Float64,N}(1.0) * MultiFloat{Float64,N}(2.0)) for N=2:8], 3)
Polynomial(-8.999999999999716 + 8.999999999999936*x - 4.0*x^2 + 2.0000000000000004*x^3)

julia> Polynomials.fit(2:8, [GFlops.flop(@count_ops MultiFloat{Float64,N}(1.0) + MultiFloat{Float64,N}(2.0)) for N=2:8], 3)
Polynomial(-9.00000000000006 + 4.00000000000002*x + 2.9999999999999987*x^2)

julia> Polynomials.fit(2:8, [GFlops.flop(@count_ops MultiFloat{Float64,N}(1.0) - MultiFloat{Float64,N}(2.0)) for N=2:8], 3)
Polynomial(-9.00000000000006 + 4.00000000000002*x + 2.9999999999999987*x^2)
```

with this PR to count fma's too: https://github.com/triscale-innov/GFlops.jl/pull/12.
