### PR TITLE
Better stopgaps for log1p and expm1

### DIFF
--- a/src/MultiFloats.jl
+++ b/src/MultiFloats.jl
@@ -496,12 +496,12 @@ function Base.log(x::MultiFloat{T,N}) where {T,N}
 end
 
 function Base.log1p(x::MultiFloat{T,N}) where {T,N}
-    y = x+1
-    return Base.log(y)
+    return 2*atanh(x/(2+x))
 end
 
 function Base.expm1(x::MultiFloat{T,N}) where {T,N}
-    return Base.exp(x)-1
+    t = tanh(x/2)
+    return 2*t/(1-t)
 end
 
 ############################################## BIGFLOAT TRANSCENDENTAL STOP-GAPS

--- a/src/MultiFloats.jl
+++ b/src/MultiFloats.jl
@@ -495,10 +495,19 @@ function Base.log(x::MultiFloat{T,N}) where {T,N}
     return y
 end
 
+function Base.log1p(x::MultiFloat{T,N}) where {T,N}
+    y = x+1
+    return Base.log(y)
+end
+
+function Base.expm1(x::MultiFloat{T,N}) where {T,N}
+    return Base.exp(x)-1
+end
+
 ############################################## BIGFLOAT TRANSCENDENTAL STOP-GAPS
 
 BASE_TRANSCENDENTAL_FUNCTIONS = [
-    :exp2, :exp10, :expm1, :log2, :log10, :log1p,
+    :exp2, :exp10, :log2, :log10,
     :sin, :cos, :tan, :sec, :csc, :cot,
     :sinpi, :cospi,
     :sinh, :cosh, :tanh, :sech, :csch, :coth,


### PR DESCRIPTION
Hey, 

Thanks a lot for what you did a while back about these stopgaps: this improved a lot my workflow and my runtime ! However i saw that the only two that i am calling these days are log1p and exp1m, and those might not need BigFloat at all.

This two functions are easier to remove from the BigFloat stopgaps than others, even if the algorithms are not the expected ones the result should still be OK, and way faster.

This should NOT be the final implementation: these functions exists because of catastrophic cancellation, and they should be re-implmeented properly. But in the mean time, these are way better than the BigFloat stopgaps. 

