### PR TITLE
add non-integer powers

### DIFF
--- a/src/MultiFloats.jl
+++ b/src/MultiFloats.jl
@@ -1283,15 +1283,10 @@ function power_by_squaring(x, p::Integer)
     return y
 end
 
-@inline function Base.:(^)(r::_MF{T,N}, n::_MF{T,N}) where {T, N}
-    if isinteger(n) && n ≤ min(2^20, maxintfloat(T, Int64))
-        return r^Int64(first(n._limbs))
-    else
-        return exp(n * log(r))
-    end
-end
-
-@inline Base.:(^)(r::_MFV{M,T,N}, n::_MFV{M,T,N}) where {M,T,N} = exp(n * log(r))
+@inline Base.:(^)(r::_MF{T,N}, n::_MF{T,N}) where {T,N} =
+    exp2(n * log2(r))
+@inline Base.:(^)(r::_MFV{M,T,N}, n::_MFV{M,T,N}) where {M,T,N} =
+    exp2(n * log2(r))
 
 ######################################################### SQUARE ROOT OPERATIONS
 


### PR DESCRIPTION
Now that there's an implementation of `exp` and `log` we get non-integer powers for free.